### PR TITLE
Add nullable to Otp attempts and expireAt

### DIFF
--- a/src/Models/Components/Otp.php
+++ b/src/Models/Components/Otp.php
@@ -32,14 +32,14 @@ class Otp
      * @var int $attempts
      */
     #[\Speakeasy\Serializer\Annotation\SerializedName('attempts')]
-    public int $attempts;
+    public ?int $attempts;
 
     /**
      *
      * @var int $expireAt
      */
     #[\Speakeasy\Serializer\Annotation\SerializedName('expire_at')]
-    public int $expireAt;
+    public ?int $expireAt;
 
     /**
      * @param  VerificationStatus  $status
@@ -47,7 +47,7 @@ class Otp
      * @param  int  $attempts
      * @param  int  $expireAt
      */
-    public function __construct(VerificationStatus $status, Strategy $strategy, int $attempts, int $expireAt)
+    public function __construct(VerificationStatus $status, Strategy $strategy, ?int $attempts, ?int $expireAt)
     {
         $this->status = $status;
         $this->strategy = $strategy;


### PR DESCRIPTION
Since attempts and expireAt may be NULL in the `[GET] /users` API return, we must add nullable to property type, otherwise it will shows errors:

> Cannot assign null to property Clerk\Backend\Models\Components\Otp::$attempts of type int

![image](https://github.com/user-attachments/assets/155f6430-85f8-4e75-b523-9ae779d59647)
