### PR TITLE
Fixed PHP method invocation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ class UserAuthentication
 
         $requestState = AuthenticateRequest::authenticateRequest($request, $options);
 
-        return $requestState.isSignedIn();
+        return $requestState->isSignedIn();
     }
 }
 ```


### PR DESCRIPTION
Fixed the typo in the documentation regarding invoking the `isSignedIn()` method to use the correct PHP syntax, instead of the JS syntax.