### PR TITLE
TypeError when using Components\Actor in CreateActorTokenRequ…

### DIFF
--- a/src/Models/Components/Actor.php
+++ b/src/Models/Components/Actor.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace Clerk\Backend\Models\Components;
 
 
-class Actor
+class Actor extends \Clerk\Backend\Models\Operations\Actor
 {
 
     public function __construct()


### PR DESCRIPTION
## Fix

Made Components\Actor extend Operations\Actor.
This way, both classes work in the constructor without breaking compatibility.

## Validation

`
php -r 'require "vendor/autoload.php"; $a=new \Clerk\Backend\Models\Components\Actor(); $a->sub="user_123"; $b=new \Clerk\Backend\Models\Operations\CreateActorTokenRequestBody("user_123",$a); echo json_encode($b);'
`

<img width="1061" height="291" alt="Captura de tela 2025-09-20 012159" src="https://github.com/user-attachments/assets/972a3765-faa6-4d93-8d28-16823ee8e029" />

Output after fix:

`{"userId":"user_123","actor":{"sub":"user_123","additionalProperties":null},"expiresInSeconds":3600,"sessionMaxDurationInSeconds":1800}
`

The bug only occurs if a developer imports Components\Actor instead of Operations\Actor. However, since both classes exist with the same name, it’s easy to make this mistake even for experienced developers (autocomplete/IDE often suggests Components fo example). The result is a fatal runtime error, this PR eliminates that pitfall with a minimal and backwards-compatible change.